### PR TITLE
Implement Slots

### DIFF
--- a/src/CompileEndRenderDirective.php
+++ b/src/CompileEndRenderDirective.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\ViewComponents;
+
+final class CompileEndRenderDirective
+{
+    public function __invoke(): string
+    {
+        return "<?php echo app(Spatie\ViewComponents\ComponentFactory::class)->renderComponent(); ?>";
+    }
+}

--- a/src/CompileEndSlotDirective.php
+++ b/src/CompileEndSlotDirective.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\ViewComponents;
+
+final class CompileEndSlotDirective
+{
+    public function __invoke(): string
+    {
+        return "<?php app(Spatie\ViewComponents\ComponentFactory::class)->endSlot(); ?>";
+    }
+}

--- a/src/CompileRenderDirective.php
+++ b/src/CompileRenderDirective.php
@@ -4,14 +4,6 @@ namespace Spatie\ViewComponents;
 
 final class CompileRenderDirective
 {
-    /** @var \Spatie\ViewComponents\ComponentFinder */
-    private $componentFinder;
-
-    public function __construct(ComponentFinder $componentFinder)
-    {
-        $this->componentFinder = $componentFinder;
-    }
-
     public function __invoke(string $expression): string
     {
         $expressionParts = explode(',', $expression, 2);

--- a/src/CompileSlotDirective.php
+++ b/src/CompileSlotDirective.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\ViewComponents;
+
+final class CompileSlotDirective
+{
+    public function __invoke(string $expression): string
+    {
+        return "<?php app(Spatie\ViewComponents\ComponentFactory::class)->slot({$expression}); ?>";
+    }
+}

--- a/src/CompileStartRenderDirective.php
+++ b/src/CompileStartRenderDirective.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\ViewComponents;
+
+final class CompileStartRenderDirective
+{
+    public function __invoke(string $expression): string
+    {
+        $expressionParts = explode(',', $expression, 2);
+
+        $componentPath = $expressionParts[0];
+        $props = trim($expressionParts[1] ?? '[]');
+
+        return "<?php app(Spatie\ViewComponents\ComponentFactory::class)->startComponent(app(Spatie\ViewComponents\ComponentFinder::class)->find({$componentPath}), {$props}); ?>";
+    }
+}

--- a/src/ComponentFactory.php
+++ b/src/ComponentFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\ViewComponents;
+
+use Illuminate\View\Concerns\ManagesComponents;
+
+final class ComponentFactory
+{
+    use ManagesComponents;
+
+    /**
+     * Get the evaluated view contents for the given component.
+     *
+     * @param  string  $component
+     * @param  array   $data
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function make($component, $data = [])
+    {
+        return app($component, $data)->toHtml();
+    }
+}

--- a/src/ViewComponentsServiceProvider.php
+++ b/src/ViewComponentsServiceProvider.php
@@ -7,6 +7,10 @@ use Illuminate\Support\ServiceProvider;
 
 class ViewComponentsServiceProvider extends ServiceProvider
 {
+    public $singletons = [
+        ComponentFactory::class => ComponentFactory::class,
+    ];
+
     public function boot()
     {
         $this->publishes([
@@ -16,6 +20,26 @@ class ViewComponentsServiceProvider extends ServiceProvider
         Blade::directive(
             'render',
             $this->app->make(CompileRenderDirective::class)
+        );
+
+        Blade::directive(
+            'startrender',
+            $this->app->make(CompileStartRenderDirective::class)
+        );
+
+        Blade::directive(
+            'endrender',
+            $this->app->make(CompileEndRenderDirective::class)
+        );
+
+        Blade::directive(
+            'namedslot',
+            $this->app->make(CompileSlotDirective::class)
+        );
+
+        Blade::directive(
+            'endnamedslot',
+            $this->app->make(CompileEndSlotDirective::class)
         );
     }
 


### PR DESCRIPTION
This PR implement slots feature.

This isn't a finished job yet. It's missing tests. But I want to make some questions before.

Follows bellow an example of my implementation:
```php
<?php

namespace App\Http\ViewComponents;

use Illuminate\Contracts\Support\Htmlable;

class CardComponent implements Htmlable
{
    private $slot;

    private $title;

    private $class;

    public function __construct($slot, $title = 'Default Title', $class = '')
    {
        $this->slot = $slot;

        $this->title = $title;

        $this->class = $class;
    }

    public function toHtml()
    {
        return view('components.card')->with([
            'slot'  => $this->slot,
            'title' => $this->title,
            'class' => $this->class,
        ]);
    }
}
```
```php
<div class="card-box {{ $class }}">
    <h3 class="card-box__title">
        {{ $title }}
    </h3>
    <div class="card-box__content">
        {{ $slot }}
    </div>
</div>
```
```php
@startrender('cardComponent', ['class' => 'test'])
    @namedslot('title')
        Title
    @endnamedslot
    Content
@endrender
```
It should create this html:
```html
<div class="card-box test">
    <h3 class="card-box__title">
        Title
    </h3>
    <div class="card-box__content">
        Content
    </div>
</div>
```
My doubt is about the directives names. I tried to avoid current api change and conflicts with laravel's default directives. That is why I created these new directives. But I think that these aren't the best names. Any suggestions?

Finally, sorry if any sentence sounded strange. English is not my native language.