### PR TITLE
Convert str_contains helper to Str::contains method

### DIFF
--- a/src/ComponentFinder.php
+++ b/src/ComponentFinder.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ViewComponents;
 
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -42,7 +43,7 @@ final class ComponentFinder
 
     private function expandComponentClassPath(string $path): string
     {
-        if (str_contains($path, '::')) {
+        if (Str::contains($path, '::')) {
             list($namespaceAlias, $path) = explode('::', $path, 2);
         }
 


### PR DESCRIPTION
Laravel 5.8 [deprecates the string and array helper functions](https://laravel.com/docs/master/upgrade#string-and-array-helpers) and each
use needs to be converted to the appropriate Str/Arr helper method to stay
compatible.