### PR TITLE
Fix a to long line error for the PSR2

### DIFF
--- a/src/CompileRenderDirective.php
+++ b/src/CompileRenderDirective.php
@@ -19,6 +19,7 @@ final class CompileRenderDirective
         $componentPath = $expressionParts[0];
         $props = trim($expressionParts[1] ?? '[]');
 
-        return "<?php echo app(app(Spatie\ViewComponents\ComponentFinder::class)->find({$componentPath}), {$props})->toHtml(); ?>";
+        return "<?php echo app(app(Spatie\ViewComponents\ComponentFinder::class)->find({$componentPath}), ".
+            "{$props})->toHtml(); ?>";
     }
 }


### PR DESCRIPTION
While working on #15 I found a PSR2 error, this PR split the line to fix that.

The error:
```FILE: /var/www/laravel-view-components/src/CompileRenderDirective.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 22 | WARNING | Line exceeds 120 characters; contains 131 characters
----------------------------------------------------------------------```