### PR TITLE
Update ViewComponentsServiceProvider.php

### DIFF
--- a/src/ViewComponentsServiceProvider.php
+++ b/src/ViewComponentsServiceProvider.php
@@ -13,7 +13,7 @@ class ViewComponentsServiceProvider extends ServiceProvider
             __DIR__.'/../config/view-components.php' => config_path('view-components.php'),
         ], 'config');
 
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+        $this->callAfterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
             $bladeCompiler->directive('render', $this->app->make(CompileRenderDirective::class));
         });
     }


### PR DESCRIPTION
Replace `$this->app->afterResolving` with `$this->callAfterResolving` which makes sure the callback gets triggered even if `blade.compiler` had already resolved before this service provider booted.

fixes #21 